### PR TITLE
pex 2.1.56

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -531,6 +531,6 @@ def pex_repositories():
     http_file(
         name = "pex_bin",
         executable = True,
-        urls = ["https://github.com/pantsbuild/pex/releases/download/v2.1.16/pex"],
-        sha256 = "38712847654254088a23394728f9a5fb93c6c83631300e7ab427ec780a88f653",
+        urls = ["https://github.com/pantsbuild/pex/releases/download/v2.1.28/pex"],
+        sha256 = "bfc0add2649bd2d76043ef4ec07edf28aa3bf2654e8ee9b8e39ff5dcffb37665",
     )

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -303,6 +303,7 @@ pex_attrs = {
         flags = ["DIRECT_COMPILE_TIME_INPUT"],
         allow_files = req_file_types,
     ),
+    # TODO support `--pex-repository` option to leverage shared requirements pex files to minimize redo-ing requirements resolutions (https://github.com/pantsbuild/pex/pull/1182)
     "no_index": attr.bool(default = False),
     "disable_cache": attr.bool(default = False),
     "repos": attr.label_list(

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -215,6 +215,7 @@ def _pex_binary_impl(ctx):
     elif script:
         arguments += ["--script", script]
     arguments += [
+        # TODO set `--tmpdir` option within the build work dir so we stop putting temp files under `/tmp` and filling up root
         "--resources-directory",
         "{resources_dir}".format(
             resources_dir = resources_dir.path,

--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -190,6 +190,10 @@ def _pex_binary_impl(ctx):
     arguments = ["setuptools==44.1.0"]
 
     # form the arguments to pex builder
+    for egg in py.transitive_eggs.to_list():
+        arguments += [egg.path]
+    for req in py.transitive_reqs.to_list():
+        arguments += [req]
     if not ctx.attr.zip_safe:
         arguments += ["--not-zip-safe"]
     if not ctx.attr.use_wheels:
@@ -206,10 +210,6 @@ def _pex_binary_impl(ctx):
         arguments += ["--requirement", req_file.path]
     for repo in repos:
         arguments += ["--repo", repo]
-    for egg in py.transitive_eggs.to_list():
-        arguments += [egg.path]
-    for req in py.transitive_reqs.to_list():
-        arguments += [req]
     if main_pkg:
         arguments += ["--entry-point", main_pkg]
     elif script:
@@ -533,6 +533,6 @@ def pex_repositories():
     http_file(
         name = "pex_bin",
         executable = True,
-        urls = ["https://github.com/pantsbuild/pex/releases/download/v2.1.28/pex"],
-        sha256 = "bfc0add2649bd2d76043ef4ec07edf28aa3bf2654e8ee9b8e39ff5dcffb37665",
+        urls = ["https://github.com/pantsbuild/pex/releases/download/v2.1.56/pex"],
+        sha256 = "aff02e2ef0212db4531354e9b7b0d5f61745b3eb49665bc11142f0b603a27db9",
     )


### PR DESCRIPTION
- updating to pex 2.1.56
- `resource-dir` is deprecated in favor of `sources-dir`
- Added support to pick up `PEX_TMP_DIR` env var so that it can be supplied to pex as `--tmpdir`
- Removed zipsafe argument since it's deprecated and defaults to not-zip-safe