### PR TITLE
Set SETUPTOOLS_USE_DISTUTILS=stdlib env var

### DIFF
--- a/pex/pex_rules.bzl
+++ b/pex/pex_rules.bzl
@@ -244,6 +244,7 @@ def _pex_binary_impl(ctx):
             # TODO allow overriding PATH
             "PATH": "/bin:/usr/bin:/usr/local/bin",
             "PEX_VERBOSE": str(ctx.attr.verbosity),
+            "SETUPTOOLS_USE_DISTUTILS": "stdlib",
         },
         arguments = arguments,
     )


### PR DESCRIPTION
* pex_binary rule is not respecting --action_env. So, direcly set the env var in the source
* setuptools v60.0.0 is causing breaking changes and setting the above env var is needed to avoid build issues: https://setuptools.pypa.io/en/latest/history.html#v60-0-0
* When building a dependent lib (for eg: SQLAlchemy), pip installs the build requirements in a separate tmp dir. Here the versions it chooses completely depends on the versions defined in the libs. So, even if we have setuptools 44.1.0 in our venv pip can still end up using the latest version (60.0.0) when building the dependent libs. Sample log which showcases this:
```
  Added sqlalchemy==1.3.15 from https://files.pythonhosted.org/packages/8c/30/4134e726dd5ed13728ff814fa91fc01c447ad8700504653fe99d91fdd34b/SQLAlchemy-1.3.15.tar.gz#sha256=c4cca4aed606297afbe90d4306b49ad3a4cd36feb3f87e4bfd655c57fd9ef445 (from sixsense-base==0.0.3) to build tracker '/tmp/pip-req-tracker-23aqztdu'
  Created temporary directory: /tmp/pip-build-env-jdzf9rab
  Installing build dependencies: started
  Running command /usr/bin/python3.7 /tmp/tmpaEtD9S/pip.pex/aef609891d42d65c887d1aeee58c46f6713a7e49/.deps/pip/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-jdzf9rab/overlay --no-warn-script-location -v --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
```
[pex_build.log.txt](https://github.com/georgeliaw/bazel_rules_pex/files/7747152/pex_build.log.txt)

